### PR TITLE
Uppercases id on title searches

### DIFF
--- a/MapleLib/Database.cs
+++ b/MapleLib/Database.cs
@@ -81,11 +81,13 @@ namespace MapleLib
 
         public static Title FindTitle(string id)
         {
+            id = id.ToUpperInvariant();
             return WiiuTitles.Find(id).FirstOrDefault();
         }
 
         public static MapleList<GraphicPack> FindGraphicPacks(string id)
         {
+            id = id.ToUpperInvariant();
             return GraphicPacks.Find(id);
         }
 

--- a/MapleLib/Databases/WiiuTitleDatabase.cs
+++ b/MapleLib/Databases/WiiuTitleDatabase.cs
@@ -77,6 +77,7 @@ namespace MapleLib.Databases
         /// <inheritdoc />
         public MapleList<Title> Find(string id)
         {
+            id = id.ToUpperInvariant();
             var col = LiteDatabase.GetCollection<Title>(CollectionName);
 
             if (!col.Exists(x => x.ID == id))


### PR DESCRIPTION
Allows the user to search for an id search without having to uppercase it
manually